### PR TITLE
Exposing immer's ability to produce patches

### DIFF
--- a/__tests__/use-reducer-integration.test.tsx
+++ b/__tests__/use-reducer-integration.test.tsx
@@ -18,11 +18,11 @@ test("can use with React.useReducer()", () => {
     }
 
     const ActionCreators = createActionCreators(Reducer);
-    const reducerFuntion = createReducerFunction(Reducer);
+    const reducerFunction = createReducerFunction(Reducer);
 
     function Foo() {
         const [state, dispatch] = React.useReducer(
-            reducerFuntion,
+            reducerFunction,
             initialState,
         );
 


### PR DESCRIPTION
Please see the README and the additional test cases for an explanation of the new behavior.  I would like to be able to produce patches of my redux state so that I can track state in a worker worker and sync relevant bits of the state to the UI/main thread.